### PR TITLE
status component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `BLANK` option to `STATUSES` enum in StatusIcon
+- StatusIcon now accepts optional `color` prop 
+
 ## [1.11.0] - 2023-04-21
 
 ### Added

--- a/src/components/status-icon/README.md
+++ b/src/components/status-icon/README.md
@@ -21,6 +21,11 @@ function MyComponent() {
 ### Props
 
 - status (enum): One of possible statuses included in the `STATUSES` enum
+- color (string): A CSS color string (see example below)
+
+```jsx
+<StatusIcon color="#FF00999" />
+```
 
 ### Statuses
 
@@ -30,3 +35,4 @@ Possible statuses in the `STATUSES` enum are:
 - `StatusIcon.STATUSES.WARNING`
 - `StatusIcon.STATUSES.CRITICAL`
 - `StatusIcon.STATUSES.UNKNOWN`
+- `StatusIcon.STATUSES.BLANK`

--- a/src/components/status-icon/index.js
+++ b/src/components/status-icon/index.js
@@ -11,12 +11,16 @@ const STATUSES = {
   BLANK: 'blank',
 };
 
-const StatusIcon = ({ status = STATUSES.UNKNOWN }) => (
-  <span className={`${styles['status-icon']} ${styles[status]}`} />
+const StatusIcon = ({ status = STATUSES.UNKNOWN, color: backgroundColor }) => (
+  <span
+    className={`${styles['status-icon']} ${styles[status]}`}
+    style={{ backgroundColor }}
+  />
 );
 
 StatusIcon.propTypes = {
   status: PropTypes.oneOf(Object.values(STATUSES)),
+  color: PropTypes.string,
 };
 
 StatusIcon.STATUSES = STATUSES;

--- a/src/components/status-icon/index.js
+++ b/src/components/status-icon/index.js
@@ -8,6 +8,7 @@ const STATUSES = {
   WARNING: 'warning',
   CRITICAL: 'critical',
   UNKNOWN: 'unknown',
+  BLANK: 'blank',
 };
 
 const StatusIcon = ({ status = STATUSES.UNKNOWN }) => (

--- a/src/components/status-icon/index.scss
+++ b/src/components/status-icon/index.scss
@@ -2,6 +2,7 @@ $success: #01A76A;
 $warning: #FFD23D;
 $critical: #F5554B;
 $unknown: #9EA5A9;
+$blank: transparent;
 
 .status-icon {
   display: inline-block;
@@ -20,5 +21,8 @@ $unknown: #9EA5A9;
   }
   &.unknown {
     background-color: $unknown;
+  }
+  &.blank {
+    background-color: $blank;
   }
 }


### PR DESCRIPTION
- add a `STATUSES.BLANK` to the `STATUSES` enum
- accepts optional `color` prop for the status icon