### PR TITLE
fix: multiple issues with time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- TimeRangePicker - custom date/times get set to blank on closing custom section
+- TimePicker - changing start time does not update list of times in dropdown 
+
 ## [1.23.1] - 2024-07-31
 
 ### Fixed

--- a/src/components/time-picker/index.js
+++ b/src/components/time-picker/index.js
@@ -38,8 +38,10 @@ const TimePicker = ({ time, validFrom, validTill, onChange }) => {
   const [filter, setFilter] = useState('');
   const [times, setTimes] = useState([]);
 
-  const isValidTimeWrapper = (ts) =>
-    isValidTime(ts, validFrom, validTill, time);
+  const isValidTimeWrapper = useCallback(
+    (ts) => isValidTime(ts, validFrom, validTill, time),
+    [time, validFrom, validTill]
+  );
 
   useEffect(() => {
     if (!filter) {
@@ -81,7 +83,7 @@ const TimePicker = ({ time, validFrom, validTill, onChange }) => {
       }
       setTimes(matches);
     }
-  }, [filter]);
+  }, [filter, isValidTimeWrapper]);
 
   const clickHandler = useCallback(
     (e, t) => {

--- a/src/components/time-range-picker/index.js
+++ b/src/components/time-range-picker/index.js
@@ -154,16 +154,20 @@ const TimeRangePicker = ({
     setIsCustomOpen(false);
   };
 
-  const changeHandler = useCallback((_, o) => {
-    if (!o) {
-      setBeginTime(null);
-      setEndTime(null);
-      setIsCustomOpen(false);
-    }
-    setOpened(o);
-  }, []);
+  const changeHandler = useCallback(
+    (_, o) => {
+      if (!o && selected !== TEXTS.CUSTOM) {
+        setBeginTime(null);
+        setEndTime(null);
+        setIsCustomOpen(false);
+      }
+      setOpened(o);
+    },
+    [selected]
+  );
 
   const toggleCustomHandler = () => {
+    if (selected === TEXTS.CUSTOM && isCustomOpen) return;
     if (!isCustomOpen) {
       if (timeRange && timeRange['begin_time'] && timeRange['end_time']) {
         setBeginTime(timeRange['begin_time']);
@@ -189,6 +193,7 @@ const TimeRangePicker = ({
   }, [beginTime, endTime]);
 
   const cancelCustomHandler = useCallback((e) => {
+    e.preventDefault();
     e.stopPropagation();
     setIsCustomOpen(false);
   }, []);
@@ -285,6 +290,7 @@ const TimeRangePicker = ({
                     <Button
                       variant={Button.VARIANT.TERTIARY}
                       sizeType={Button.SIZE_TYPE.SMALL}
+                      disabled={selected === TEXTS.CUSTOM}
                       onClick={cancelCustomHandler}
                     >
                       {TEXTS.CANCEL}


### PR DESCRIPTION
Fixes:
- when custom date/time is selected, closed and reopened, date/time would get set to blank (`TimeRangePicker`)
- clicking cancel button in custom time would set custom date/time to blank (`TimeRangePicker`)
- when `validFrom` changes in `TimePicker`, it wouldn't update the dropdown of valid time values 